### PR TITLE
Queue takes generic message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,17 +20,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
-name = "async-trait"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atoi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,7 +869,6 @@ name = "rusie-queue"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "chrono",
  "futures",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ tokio = { version = "1", features = ["full"] }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "chrono", "uuid", "json" ] }
 chrono = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 anyhow = "1"
 ulid = { version = "0.4", features = ["uuid"] }
 futures = "0.3"
+
+[features]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,26 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use uuid::Uuid;
-
-#[async_trait::async_trait]
-pub trait Queue: Send + Sync + Debug {
-    async fn push(
-        &self,
-        job: Message,
-        scheduled_for: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<(), crate::Error>;
-    /// pull fetches at most `number_of_jobs` from the queue.
-    async fn pull(&self, number_of_jobs: u32) -> Result<Vec<Job>, crate::Error>;
-    async fn delete_job(&self, job_id: Uuid) -> Result<(), crate::Error>;
-    async fn fail_job(&self, job_id: Uuid) -> Result<(), crate::Error>;
-    async fn clear(&self) -> Result<(), crate::Error>;
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Job {
-    pub id: Uuid,
-    pub message: Message,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Message {


### PR DESCRIPTION
supersedes #2, #3.

this imposes an opaque serialize/deserialization bound on stored jobs, and removes some of the abstractions initially put in place that were causing a bit of confusion to @CDThomas. `async-trait` is a bit iffy, and the need for the `'static` bound here for `pull` is a bit silly, but alas.

tests are still majorly broken, but everything compiles and default binary runs.

```
; RUSTFLAGS= cargo run
   Compiling rusie-queue v0.1.0 (/home/rjs/repos/rusie-queue)
    Finished dev [unoptimized + debuginfo] target(s) in 4.30s
     Running `target/debug/rusie-queue`
Fetched 1 jobs
Sending sign in email: SendSignInEmail { email: "your@email.com", name: "Sylvain Kerkour", code: "
000-000" }
```
